### PR TITLE
Support fonts with spaces in the filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function getter() {
 			var requests = [];
 			css.replace(rx, function (block, family, style, weight, url) {
 				var name = [family, style, weight].join('-') + '.woff';
-				requests.push({ family: family, style: style, weight: weight, name: name, url: url });
+				requests.push({ family: family, style: style, weight: weight, name: name.replace(' ', '_'), url: url });
 			});
 			generateFontCss(requests);
 			next(null, requests);


### PR DESCRIPTION
Hi! Thanks for providing this useful plugin. I've discovered that fonts with spaces in the name do not work correctly. This happens because using the unquoted filename in `font-face[src]` wouldn't be valid when the filename contains spaces. I've added a fix for this, replacing the spaces with underscores. An alternative fix would be to just quote the `src` property.
