### PR TITLE
Fix bug that duplicated custom font directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ function getter(options) {
 
 				function emitFont(name, stream, next) {
 					self.push(new File({
-						path: path.join(options.fontsDir, name),
+						path: name,
 						contents: stream
 					}));
 					next();


### PR DESCRIPTION
Fixes a bug introduced by b3f9818d292b906da60ceebcc161582c119c6ae8 that duplicated the custom font directory. The directory was added the first time [here](https://github.com/battlesnake/gulp-google-webfonts/blob/b3f9818d292b906da60ceebcc161582c119c6ae8/index.js#L137) and then again [here](https://github.com/battlesnake/gulp-google-webfonts/blob/b3f9818d292b906da60ceebcc161582c119c6ae8/index.js#L157).
