### PR TITLE
Fix path.join about the path construction

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,7 +206,7 @@ function getter(options) {
 			writeFile(path.join(options.cssDir, options.cssFilename), new Buffer(css), function (err) { next(err, requests); });
 
 			function makeFontFace(request) {
-				request.name = path.posix.join(options.fontsDir, request.name);
+				request.name = path.join(options.fontsDir, request.name);
 				return template
 					.replace(/\$(\w+)/g, function (m, name) { return request[name]; });
 			}


### PR DESCRIPTION
Was experiencing an issue when using the module. Not sure if this will solve the problem.

/tmp/glp/node_modules/gulp-google-webfonts/index.js:209
                request.name = path.posix.join(options.fontsDir, request.name);
                                          ^
TypeError: Cannot call method 'join' of undefined
    at makeFontFace (/tmp/glp/node_modules/gulp-google-webfonts/index.js:209:31)
    at Array.map (native)
    at generateFontCss (/tmp/glp/node_modules/gulp-google-webfonts/index.js:204:6)
    at parseCss (/tmp/glp/node_modules/gulp-google-webfonts/index.js:191:4)
    at fn (/tmp/glp/node_modules/gulp-google-webfonts/node_modules/async/lib/async.js:638:34)
    at Object._onImmediate (/tmp/glp/node_modules/gulp-google-webfonts/node_modules/async/lib/async.js:554:34)
    at processImmediate [as _immediateCallback](timers.js:330:15)
