### PR TITLE
Add local sources in css

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,14 +237,14 @@ function getter(options) {
 					"\\s*font-family:\\s*'([^']+)';",
 					"\\s*font-style:\\s*(\\w+);",
 					"\\s*font-weight:\\s*(\\w+);",
-					"\\s*src:[^;]*url\\(([^)]+)\\)[^;]*;",
+					"\\s*src:\\s*local\\('([^']+)'\\),\\s*local\\('([^']+)'\\),\\s*url\\(([^)]+)\\)[^;]*;",
 					".*(?:unicode-range:([^;]+);)?",
 				].join(''), 'm');
 
 				return formatData.apply(null, block.match(re, 'm'));
 
 
-				function formatData(block, family, style, weight, url, range) {
+				function formatData(block, family, style, weight, local1, local2, url, range) {
 					var name = [family, style, weight].join('-') + '.' + ext;
 					return {
 						family: family,
@@ -252,6 +252,8 @@ function getter(options) {
 						weight: weight,
 						name: name.replace(/\s/g, '_'),
 						url: url,
+						local1: local1,
+						local2: local2,
 						range: range || 'U+0-10FFFF'
 					};
 				}
@@ -274,7 +276,7 @@ function getter(options) {
 				'	font-family: \'$family\';',
 				'	font-style: $style;',
 				'	font-weight: $weight;',
-				'	src: url($uri)' + format + ';',
+				'	src: local(\'$local1\'), local(\'$local2\'), url($uri)' + format + ';',
 				'	unicode-range: $range;',
 				'}'
 			].join('\n');


### PR DESCRIPTION
This change makes it possible to generate a css that refers to local fonts when users have them.
It is related to a closed Issue #31.

Before
```css
@font-face {
	font-family: 'Roboto';
	font-style: normal;
	font-weight: 400;
	src: local('Roboto'), local('Roboto-Regular'), url(Roboto-normal-400.woff) format('woff');
	unicode-range: U+0-10FFFF;
}
```

After
```css
@font-face {
	font-family: 'Roboto';
	font-style: normal;
	font-weight: 400;
	src: url(Roboto-normal-400.woff) format('woff');
	unicode-range: U+0-10FFFF;
}
```