### PR TITLE
Adds support for local fonts without them being required

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ function getter(options) {
 				return formatData.apply(null, block.match(re, 'm'));
 
 
-				function formatData(block, family, style, weight, url, range) {
+				function formatData(block, family, style, weight, local1, local2, url, range) {
 					var name = [family, style, weight].join('-') + '.' + ext;
 					return {
 						family: family,
@@ -254,6 +254,8 @@ function getter(options) {
 						weight: weight,
 						name: name.replace(/\s/g, '_'),
 						url: url,
+						local1: local1,
+						local2: local2,
 						range: range || 'U+0-10FFFF'
 					};
 				}
@@ -277,7 +279,7 @@ function getter(options) {
 				'	font-style: $style;',
 				'	font-weight: $weight;',
 				'	font-display: ' + options.fontDisplayType + ';',
-				'	src: url($uri)' + format + ';',
+				'	src: local(\'$local1\'), local(\'$local2\'), url($uri)' + format + ';',
 				'	unicode-range: $range;',
 				'}'
 			].join('\n');
@@ -300,7 +302,7 @@ function getter(options) {
 				return template
 					.replace(/\$(\w+)/g, function (m, name) {
 						return request[name];
-					});
+					}).replace(/local\('undefined'\), /g, '');
 			}
 		}
 

--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ function getter(options) {
 					"\\s*font-family:\\s*'([^']+)';",
 					"\\s*font-style:\\s*(\\w+);",
 					"\\s*font-weight:\\s*(\\w+);",
-					"\\s*src:[^;]*url\\(([^)]+)\\)[^;]*;",
+					"\\s*src:(?:\\s*local\\('([^']+)'\\),)?(?:\\s*local\\('([^']+)'\\),)?\\s*url\\(([^)]+)\\)[^;]*;",
 					".*(?:unicode-range:([^;]+);)?",
 				].join(''), 'm');
 


### PR DESCRIPTION
This change adds support for local fonts, as some already tried before, but not all fonts have local sources.
This also fixes the output in case there is no local font

In hindsight; I would have done this totally different, but this is a fix of the currently available version of gulp-google-webfonts as installed by node, which is version 2.1.0

example with local:

@font-face {
  font-family: 'Montserrat';
  font-style: normal;
  font-weight: 400;
  src: local('Montserrat Regular'), local('Montserrat-Regular'), url(https://fonts.gstatic.com/s/montserrat/v14/JTUSjIg1_i6t8kCHKm459WlhzQ.woff) format('woff');
}

example without:

@font-face {
  font-family: 'Roboto Slab';
  font-style: normal;
  font-weight: 400;
  src: url(https://fonts.gstatic.com/s/robotoslab/v11/BngbUXZYTXPIvIBgJJSb6s3BzlRRfKOFbvjojISmb2Rl.woff) format('woff');
}

This commit adds support for local fonts without them being required.